### PR TITLE
feat: Inclusão de modo de desenvolvimento

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "assinador",
-  "version": "4.2.4",
+  "version": "4.2.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10943,7 +10943,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "cli-truncate": "^1.1.0"
+        "cli-truncate": "^1.1.0",
+        "node-addon-api": "^1.6.3"
       }
     },
     "iconv-lite": {
@@ -13710,6 +13711,13 @@
       "requires": {
         "semver": "^5.4.1"
       }
+    },
+    "node-addon-api": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
+      "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
+      "dev": true,
+      "optional": true
     },
     "node-forge": {
       "version": "0.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "assinador",
-  "version": "4.2.5",
+  "version": "4.2.6",
   "description": "Assinador de Documentos do MPES",
   "author": {
     "name": "Ministério Público do Espírito Santo - MPES",

--- a/src/main/config.js
+++ b/src/main/config.js
@@ -9,7 +9,8 @@ const settingsPath = path.join(app.getPath('userData'), 'settings.json');
 
 let config = {
   port: 19333,
-  libs: []
+  libs: [],
+  devMode: false
 };
 
 function readFromFile() {
@@ -17,6 +18,7 @@ function readFromFile() {
     const settingsFile = JSON.parse(fs.readFileSync(settingsPath));
     config.port = settingsFile.port;
     config.libs = settingsFile.libs;
+    config.devMode = settingsFile.devMode || false;
   } catch {
     config.libs = libManager.identify();
     persist();
@@ -32,6 +34,12 @@ export function setPort(port) {
   persist();
   server.restart();
   return config.port;
+}
+
+export function setDevMode(devMode) {
+  config.devMode = devMode;
+  persist();
+  return config.devMode;
 }
 
 readFromFile();

--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -1,7 +1,7 @@
 import { app, ipcMain, dialog } from 'electron';
 
 import libManager from './libManager';
-import config, { setPort } from './config';
+import config, { setPort, setDevMode } from './config';
 import platform from './models/platform';
 
 function getFileFilter() {
@@ -24,9 +24,13 @@ ipcMain.handle('get-port', async () => config.port);
 
 ipcMain.handle('get-libs', async () => config.libs);
 
+ipcMain.handle('get-dev-mode', async () => config.devMode);
+
 ipcMain.handle('reload-libs', async () => libManager.reloadLibs());
 
 ipcMain.handle('set-port', async (_event, port) => setPort(port));
+
+ipcMain.handle('set-dev-mode', async (_event, devMode) => setDevMode(devMode));
 
 ipcMain.handle('add-lib', async () => {
   const [result] = dialog.showOpenDialogSync(null, {

--- a/src/main/server/routes/sign.js
+++ b/src/main/server/routes/sign.js
@@ -35,13 +35,23 @@ const signRoute = (req, res) => {
     req.body = JSON.parse(body);
     validateMiddleware(req, res, () => {
       const { token, hash } = req.body;
-      const { signature, signCertificate, otherCertificates } = signer(
-        token.libraryPath,
-        token.slotId,
-        token.password,
-        Buffer.from(token.id, 'hex'),
-        Buffer.from(hash, 'base64')
-      );
+      let result;
+      if (token.libraryPath === 'test') {
+        result = {
+          signature: 'test',
+          signCertificate: 'test',
+          otherCertificates: 'test'
+        };
+      } else {
+        result = signer(
+          token.libraryPath,
+          token.slotId,
+          token.password,
+          Buffer.from(token.id, 'hex'),
+          Buffer.from(hash, 'base64')
+        );
+      }
+      const { signature, signCertificate, otherCertificates } = result;
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.write(
         JSON.stringify({

--- a/src/main/server/routes/tokens.js
+++ b/src/main/server/routes/tokens.js
@@ -7,6 +7,32 @@ const tokenRoute = async (_, res) => {
     const certs = libmanager.getCertificates(lib);
     certificates = [...certificates, ...certs];
   });
+  if (config.devMode) {
+    certificates = [
+      ...certificates,
+      {
+        id: 'a0000000',
+        displayName: 'Certificado de teste 1',
+        valid: true,
+        libraryPath: 'test',
+        slotId: 0
+      },
+      {
+        id: 'b0000000',
+        displayName: 'Certificado de teste 2',
+        valid: false,
+        libraryPath: 'test',
+        slotId: 1
+      },
+      {
+        id: 'c0000000',
+        displayName: 'Certificado de teste 3',
+        valid: true,
+        libraryPath: 'test',
+        slotId: 2
+      }
+    ];
+  }
   res.writeHead(200, { 'Content-Type': 'application/json' });
   res.write(JSON.stringify(certificates));
   res.end();

--- a/src/renderer/Config.js
+++ b/src/renderer/Config.js
@@ -9,7 +9,7 @@ import {
   Button,
   NumberInput
 } from '@chakra-ui/core';
-import { FaRecycle, FaPlus } from 'react-icons/fa';
+import { FaRecycle, FaPlus, FaBug } from 'react-icons/fa';
 import { ipcRenderer, shell } from 'electron';
 
 import Token from './components/Token';
@@ -22,6 +22,8 @@ export default function Config() {
   const [restarting, setRestart] = React.useState(false);
   const [reloading, setReload] = React.useState(false);
   const [adding, setAdd] = React.useState(false);
+  const [devMode, setDevMode] = React.useState(false);
+  const [changingDevMode, setChangingDevMode] = React.useState(false);
 
   React.useEffect(() => {
     ipcRenderer.invoke('get-version').then(results => setVersao(results));
@@ -31,6 +33,9 @@ export default function Config() {
   }, []);
   React.useEffect(() => {
     ipcRenderer.invoke('get-port').then(results => setPort(results));
+  }, []);
+  React.useEffect(() => {
+    ipcRenderer.invoke('get-dev-mode').then(results => setDevMode(results));
   }, []);
 
   return (
@@ -89,6 +94,7 @@ export default function Config() {
           variant="outline"
           size="sm"
           ml="auto"
+          w="14rem"
           isLoading={reloading}
           onClick={() => {
             setReload(true);
@@ -99,6 +105,24 @@ export default function Config() {
           }}
         >
           Recarregar valores padrão
+        </Button>
+        <Button
+          leftIcon={FaBug}
+          variantColor="white"
+          variant="outline"
+          size="sm"
+          ml="auto"
+          w="14rem"
+          isLoading={changingDevMode}
+          onClick={() => {
+            setChangingDevMode(true);
+            ipcRenderer
+              .invoke('set-dev-mode', !devMode)
+              .then(results => setDevMode(results))
+              .finally(() => setChangingDevMode(false));
+          }}
+        >
+          {devMode ? 'Desabilitar' : 'Habilitar'} modo teste
         </Button>
       </Stack>
       <Stack spacing={2}>


### PR DESCRIPTION
Na área de configuração do assinador é possível habilitar o modo desenvolvedor.
São listados 3 certificados de teste (para permitir troca) sendo 1 deles inativo.
Ao assinar com o certificado todos os atributos retornam 'test'

A sugestão para o backend é verificar que a assinatura corresponde ao teste e está em um ambiente de testes e assinar "localmente" o arquivo com o certificado do usuário para seguir o fluxo até o final.
Fix: #8